### PR TITLE
fix: Add PDF validation for Policy Query Assistant

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -244,6 +244,17 @@ _Contributors who squashed bugs_
       <br />
       <a href="https://github.com/NikhilRaikwar/HealthAI-Assistant/pull/19">#19</a>
     </td>
+    <td align="center">
+      <a href="https://github.com/SumitRaikwar18">
+        <img src="https://github.com/SumitRaikwar18.png" width="80px;" alt="Sumit Raikwar"/>
+        <br />
+        <sub><b>Sumit Raikwar</b></sub>
+      </a>
+      <br />
+      <sub>Policy PDF Validation Bug Fix</sub>
+      <br />
+      <a href="#">#TBD</a>
+    </td>
   </tr>
 </table>
 
@@ -484,8 +495,9 @@ _Most critical bug resolution_
 
 - Add interactive medical report chat with session management - PR #5
 - Add Bento Grid layout with animated hover effects - PR #9
+- Fixed Policy Query Assistant accepting non-policy PDFs with AI-powered validation - PR #TBD
 
-**Impact:** Enhanced user experience with modern UI patterns and interactive features
+**Impact:** Enhanced user experience with modern UI patterns and interactive features. Improved data integrity by implementing policy document validation to prevent invalid PDF uploads
 
 ---
 


### PR DESCRIPTION
## 📋 Description
Implemented AI-powered PDF validation for Policy Query Assistant to reject non-policy documents. The system now validates uploaded PDFs using Gemini API and keyword-based fallback, ensuring only valid health insurance policy documents are accepted and processed.


## 🎃 Hacktoberfest Participation
- [✅] 🎃 This PR is part of Hacktoberfest contributions
- [ ] 🌱 This PR includes Hacktoberfest-related features/changes
- [✅] 🏅 I am participating in Hacktoberfest 2025


## 👥 Contributors
- [✅] 🙋 I have added myself to the [CONTRIBUTORS.md](../CONTRIBUTORS.md) file in the appropriate section
- [✅] 📝 I have included details about my contribution (type, description, PR link)

**Note**: Please add yourself to the CONTRIBUTORS.md file following the format provided. This helps us recognize and celebrate all contributors! 🎉

⭐ **If you haven't already, please [star the repo](https://github.com/NikhilRaikwar/HealthAI-Assistant)!** ⭐


## 🔗 Related Issues
Fixes #26 
Closes #26 


## �️ Category of Contribution (choose one or more)
- [✅] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🎨 Style/UI
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/config
- [ ] 🔒 Security
- [ ] 📦 Dependency update


## 🧪 How Has This Been Tested?
Please describe the tests you ran to verify your changes. Add checkmarks if applicable:
- [✅] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] UI/visual tests

**Test Configuration:**
- OS: Windows
- Browser: Chrome
- Node version: Latest


## 📸 Screenshots (if applicable)
### Before
Any PDF file was accepted and processed, including non-policy documents like competition guidelines.
<img width="1920" height="1638" alt="screencapture-health-ai-assistant-vercel-app-2025-10-03-19_52_21" src="https://github.com/user-attachments/assets/d438b778-6cfd-497f-aaf4-831e0f2881cf" />

### After
Only valid health policy PDFs are accepted. Invalid documents are rejected with a clear error message.

<img width="1920" height="1091" alt="screencapture-localhost-5173-2025-10-03-19_50_04" src="https://github.com/user-attachments/assets/b83f247d-394a-4e76-b3f4-30e268188c47" />


## ✅ Checklist
- ✅ My code follows the style guidelines of this project
- ✅ I have performed a self-review of my own code
- ✅ I have commented my code, particularly in hard-to-understand areas
- ✅ I have made corresponding changes to the documentation
- ✅ My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- ✅ Any dependent changes have been merged and published
- ✅ ⭐ I have starred the repo (if not already!)

## 📝 Additional Notes
**Implementation Details:**
- Added [validatePolicyDocument()](cci:1://file:///d:/Nikhil%20Main%20Files/pr4/HealthAI-Assistant/src/lib/gemini.ts:298:0-344:2) function in [src/lib/gemini.ts](cci:7://file:///d:/Nikhil%20Main%20Files/pr4/HealthAI-Assistant/src/lib/gemini.ts:0:0-0:0) using Gemini API
- Integrated validation in [PolicyQueryAssistant.tsx](cci:7://file:///d:/Nikhil%20Main%20Files/pr4/HealthAI-Assistant/src/components/PolicyQueryAssistant.tsx:0:0-0:0) after PDF text extraction
- Implemented keyword-based fallback validation if API fails
- Updated [CONTRIBUTORS.md](cci:7://file:///d:/Nikhil%20Main%20Files/pr4/HealthAI-Assistant/CONTRIBUTORS.md:0:0-0:0) with bug fix contribution

**Validation Logic:**
- Checks for health policy keywords (insurance, coverage, premium, claims, etc.)
- Rejects competition guidelines, techathon statements, and non-policy documents
- Provides clear user feedback with error messages



## 🔄 Dependencies
N/A

## 🚀 Deployment Notes
N/A